### PR TITLE
enforce clippy in CI

### DIFF
--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -51,6 +51,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Clippy ${{ matrix.bsp }}
         args: --all-features --manifest-path=boards/${{ matrix.bsp }}/Cargo.toml
+        env:
+          RUSTFLAGS: -D warnings -D errors
 
   build_hal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary
Enforce clippy compliance better in CI

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)